### PR TITLE
Update apt repo before installing packages.

### DIFF
--- a/deps.sh
+++ b/deps.sh
@@ -1,3 +1,6 @@
+#!/bin/bash
+
+apt-get -y update
 apt-get install -y alsa-utils libasound2-dev
 chmod +x sound_start
 mv sound_start /usr/bin/sound_start


### PR DESCRIPTION
Need to `apt-get update` to get new packages otherwise required packages might be missing/outdated (we clear out the package cache once we've installed what we need by default I believe.)
